### PR TITLE
Sc/fix/post error

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -21,8 +21,11 @@ const postAPI = (user) => {
   .then(response => response.json())
   .then(data => {
     console.log(data)
+    if(data.message.includes('already')) {
+      throw new Error('Recipe already saved!');
+    }
   })
-  .catch(() => alert("Your recipe couldn't be saved!"))
+  .catch((err) => alert(err))
 }
 
 export { fetchAPI, postAPI }

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -20,7 +20,6 @@ const postAPI = (user) => {
   })
   .then(response => response.json())
   .then(data => {
-    console.log(data)
     if(data.message.includes('already')) {
       throw new Error('Recipe already saved!');
     }

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -180,8 +180,16 @@ const toggleHidden = (elements, type) => {
 
 const toggleBookmark = (e, currentUser, recipeData) => {
   if (e.target.classList[0] === 'bookmark-icon') {
-    if (isUnchecked(e)) {
+    let check = currentUser.deletedRecipes.some((recipe)=>{
+      return recipe[0].id === parseInt(e.target.id)
+    })
+    
+    if (isUnchecked(e) && !check) {
       postAPI({userID: currentUser.id, recipeID: e.target.id})
+      recipesToCook(e.target.id, currentUser, recipeData);
+      toggleHidden([e.target], 'add');
+      toggleHidden([e.target.nextElementSibling], 'remove');
+    } else if(isUnchecked(e)){
       recipesToCook(e.target.id, currentUser, recipeData);
       toggleHidden([e.target], 'add');
       toggleHidden([e.target.nextElementSibling], 'remove');

--- a/src/recipes-to-cook.js
+++ b/src/recipes-to-cook.js
@@ -28,7 +28,8 @@ const removeRecipes = (eventId, currentUser) => {
 
     const index = recipes.indexOf(`${eventId}`);
 
-    currentUser.recipesToCook.splice(index, 1);
+    const deleted = currentUser.recipesToCook.splice(index, 1);
+    currentUser.deletedRecipes.push(deleted)
   };
 };
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -51,7 +51,8 @@ const start = () => {
     currentUser = getRandomUser(userData);
     currentUser.happyRecipeRatings = [];
     currentUser.sadRecipeRatings = [];
-
+    currentUser.deletedRecipes = [];
+    
     renderRecipeCards(mainViewCardContainer, recipeData, currentUser);
   });
 };


### PR DESCRIPTION
## What is the feature?
I prevent recipe data from being posted twice to the API because we kept getting a 422 error. I also threw an error in case a 422 does happen.

## How you implemented the solution?
I created another property in the currentUser variable called deletedRecipes, and when we splice out the data from the users recipesToCook array when the user unsaves, the deleted recipe will be pushed in to the deletedRecipes array. When you go to save a recipe again, if its the second time, it will check to see if the recipe already exists in the deletedRecipes array (because that means that data will have already been posted) it will not post to the API again.

## Does it impact any other area of the project?
No, but i had to add one more statement to the recipes to cook function.